### PR TITLE
adding vias_generator as seperate pcell

### DIFF
--- a/cells/klayout/pymacros/cells/__init__.py
+++ b/cells/klayout/pymacros/cells/__init__.py
@@ -45,6 +45,7 @@ from .res import (
     pwell_resistor,
 )
 from .efuse import efuse
+from .vias_gen import via_dev
 
 
 # It's a Python class that inherits from the pya.Library class
@@ -128,6 +129,9 @@ class gf180mcu(pya.Library):
         self.layout().register_pcell(
             "ppolyf_u_high_Rs_resistor", ppolyf_u_high_Rs_resistor()
         )
+
+        # VIAS
+        self.layout().register_pcell("via_dev", via_dev())
 
         # Register us with the name "gf180mcu".
         self.register("gf180mcu")

--- a/cells/klayout/pymacros/cells/via_generator.py
+++ b/cells/klayout/pymacros/cells/via_generator.py
@@ -125,7 +125,9 @@ def via_stack(
 
         m1_y = con.size[1] + 2 * m_enc
 
-        m1 = c.add_ref(gf.components.rectangle(size=(m1_x, m1_y), layer=layer["metal1"]))
+        m1 = c.add_ref(
+            gf.components.rectangle(size=(m1_x, m1_y), layer=layer["metal1"])
+        )
         m1.xmin = con.xmin - m_enc
         m1.ymin = con.ymin - m_enc
 
@@ -159,10 +161,74 @@ def via_stack(
         m2_mx = (m2_x - (via1.xmax - via1.xmin)) / 2
         m2_my = (m2_y - (via1.ymax - via1.ymin)) / 2
 
-        m2 = c.add_ref(gf.components.rectangle(size=(m2_x, m2_y), layer=layer["metal2"]))
+        m2 = c.add_ref(
+            gf.components.rectangle(size=(m2_x, m2_y), layer=layer["metal2"])
+        )
         m2.move((via1.xmin - m2_mx, via1.ymin - m2_my))
 
     return c
+
+
+def draw_via_dev(
+    layout,
+    x_min: float = 0,
+    y_min: float = 1,
+    x_max: float = 0,
+    y_max: float = 1,
+    metal_level: str = "M1",
+    base_layer: str = "comp",
+):
+
+    """
+
+    return via stack till the metal level indicated where :
+    metal_level 1 : till m1
+    metal_level 2 : till m2
+    metal_level 3 : till m3
+    metal_level 4 : till m4
+    metal_level 5 : till m5
+    withen the range xrange and yrange and expecting the base_layer to be drawen
+
+    Args:
+        layout : layout object
+        x_min :  left x_point of vias generated
+        x_max :  right x_point of vias generated
+        y_min :  bottom y_point of vias generated
+        y_max :  top y_point of vias generated
+
+    """
+
+    c = gf.Component("via_stack_dev")
+
+    if metal_level == "M1":
+        metal_lev = 1
+    elif metal_level == "M2":
+        metal_lev = 2
+    elif metal_level == "M3":
+        metal_lev = 3
+    elif metal_level == "M4":
+        metal_lev = 4
+    else:
+        metal_lev = 5
+
+    v_stack = c.add_ref(
+        via_stack(x_range=(x_min, x_max), y_range=(y_min, y_max), metal_level=metal_lev)
+    )
+
+    if len(base_layer) > 0 and base_layer in layer:
+        base = c.add_ref(
+            gf.components.rectangle(
+                size=(x_max - x_min, y_max - y_min), layer=layer[base_layer]
+            )
+        )
+        base.center = v_stack.center
+
+    c.write_gds("via_stack_temp.gds")
+    layout.read("via_stack_temp.gds")
+    cell_name = "via_stack_dev"
+    print(type(layout.cell(cell_name)))
+
+    return layout.cell(cell_name)
 
 
 # testing the generated methods

--- a/cells/klayout/pymacros/cells/vias_gen.py
+++ b/cells/klayout/pymacros/cells/vias_gen.py
@@ -1,0 +1,102 @@
+# Copyright 2022 GlobalFoundries PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################################################################
+# MIM Capacitor Generator for GF180MCU
+########################################################################################################################
+
+import pya
+import os
+from .via_generator import draw_via_dev
+
+via_size = 0.22
+via_enc = 0.06
+
+
+class via_dev(pya.PCellDeclarationHelper):
+    """
+    Via Generator for GF180MCU
+    """
+
+    def __init__(self):
+
+        # Initializing super class.
+        super(via_dev, self).__init__()
+
+        # ===================== PARAMETERS DECLARATIONS =====================
+        self.Type_handle = self.param("metal_level", self.TypeList, "metal_level")
+        self.Type_handle.add_choice("M1", "M1")
+        self.Type_handle.add_choice("M2", "M2")
+        self.Type_handle.add_choice("M3", "M3")
+        self.Type_handle.add_choice("M4", "M4")
+        self.Type_handle.add_choice("M5", "M5")
+
+        self.param("base_layer", self.TypeString, "base_layer_name", default="comp")
+
+        self.param("x_min", self.TypeDouble, "X_min", default=0, unit="um")
+        self.param("y_min", self.TypeDouble, "Y_min", default=0, unit="um")
+        self.param("x_max", self.TypeDouble, "X_max", default=1, unit="um")
+        self.param("y_max", self.TypeDouble, "Y_max", default=1, unit="um")
+
+    def display_text_impl(self):
+        # Provide a descriptive text for the cell
+        return "via_stack"
+
+    def coerce_parameters_impl(self):
+        # We employ coerce_parameters_impl to decide whether the handle or the numeric parameter has changed.
+        #  We also update the numerical value or the shape, depending on which on has not changed.
+        if (self.x_max - self.x_min) < (via_size + (2 * via_enc)):
+            self.x_max = self.x_min + (via_size + (2 * via_enc))
+
+        if (self.y_max - self.y_min) < (via_size + (2 * via_enc)):
+            self.y_max = self.y_min + (via_size + (2 * via_enc))
+
+    def can_create_from_shape_impl(self):
+        # Implement the "Create PCell from shape" protocol: we can use any shape which
+        # has a finite bounding box
+        return self.shape.is_box() or self.shape.is_polygon() or self.shape.is_path()
+
+    def parameters_from_shape_impl(self):
+        # Implement the "Create PCell from shape" protocol: we set r and l from the shape's
+        # bounding box width and layer
+        self.r = self.shape.bbox().width() * self.layout.dbu / 2
+        self.lc = self.layout.get_info(self.layer)
+
+    def transformation_from_shape_impl(self):
+        # Implement the "Create PCell from shape" protocol: we use the center of the shape's
+        # bounding box to determine the transformation
+        return pya.Trans(self.shape.bbox().center())
+
+    def produce_impl(self):
+        np_instance = draw_via_dev(
+            self.layout,
+            x_min=self.x_min,
+            y_min=self.y_min,
+            x_max=self.x_max,
+            y_max=self.y_max,
+            metal_level=self.metal_level,
+            base_layer=self.base_layer,
+        )
+        print(type(np_instance))
+        write_cells = pya.CellInstArray(
+            np_instance.cell_index(),
+            pya.Trans(pya.Point(0, 0)),
+            pya.Vector(0, 0),
+            pya.Vector(0, 0),
+            1,
+            1,
+        )
+
+        self.cell.insert(write_cells)
+        self.cell.flatten(1)


### PR DESCRIPTION
adding via_stack as a separate pcell with the following options : 
-  metal_level : list of available metal levels (M1 -> M5)
- base_layer : string of the base used base_layer (ignored when empty or non_defined layer)
 -  x_min : define x of left_bottom point 
 -  x_max : define x of right_top point
 - y_min : define y of left_bottom point 
 -  y_max : define y of  right_top point

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR