### PR TITLE
Update gf180mcu_drc.lydrc

### DIFF
--- a/rules/klayout/macros/gf180mcu_drc.lydrc
+++ b/rules/klayout/macros/gf180mcu_drc.lydrc
@@ -111,7 +111,7 @@ $report = "antenna.lyrdb"
 $report = "density.lyrdb"
 #%include ../drc/rule_decks/density.drc
 $report = "main.lyrdb"
-#%include run_drc_main/main.drc
+#%include ../drc/rule_decks/main.drc
 
 
 </text>


### PR DESCRIPTION
Run `main.drc` from the same place for antenna and density. Klayout was not running `main.drc`, only antenna and density.

Klayout uses gfmcu_drc.lydrc to run the 3 types of DRC, density, antenna, and the main one. But the path to call these rules is different for the "`main.drc`". I know that this repo is not responsible for DRC and LVS rules, but it is responsible for calling the rules.

The repo for physical verification "_PV", klayout folder, [LINK](https://github.com/efabless/globalfoundries-pdk-libs-gf180mcu_fd_pv/tree/main/klayout), does not contain the "`klayout/macro`" folder